### PR TITLE
Fix `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,11 @@ requirements = [
     'python-osc',
 ]
 
-test_requirements = [
+setup_requirements = [
     'pytest-runner',
+]
+
+test_requirements = [
     'pytest',
 ]
 
@@ -64,4 +67,5 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
+    setup_requires=setup_requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,15 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.txt'), encoding='utf-8') as f:
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 requirements = [
     'python-osc',
 ]
 
-setup_requirements = [
-    'pytest-runner',
-]
-
 test_requirements = [
+    'pytest-runner',
     'pytest',
 ]
 
@@ -29,8 +26,7 @@ setup(
     version='0.4.1',
     description='Programming Music with Sonic Pi or Supercollider',
     long_description=long_description,
-#    long_description_content_type='text/x-rst',
-    long_description_content_type='text/plain',
+    long_description_content_type='text/x-rst',
     url='https://github.com/gkvoelkl/python-sonic',
     author='gkvoelkl',
     author_email='gkvoelkl@nelson-games.de',
@@ -68,5 +64,4 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    setup_requires=setup_requirements,
 )


### PR DESCRIPTION
Closes #34 

`setup.py` cannot actually be used for anything:
```
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    with open(path.join(here, 'README.txt'), encoding='utf-8') as f:
  File "/usr/lib/python3.8/codecs.py", line 905, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/python-sonic-0.4.1/README.txt'
Error: Process completed with exit code 1.
```