### PR TITLE
Support Sonic-Pi v4+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,11 @@ $ pip install python-sonic
 
 That should work.
 
+For local development you might want to locally install using 
+
+::
+    $ pip install -e .
+
 Limitations
 -----------
 
@@ -62,8 +67,8 @@ Communication
 -------------
 
 The API *python-sonic* communications with *Sonic Pi* over UDP and two
-  ports. One port is an internal *Sonic Pi* GUI port and the second is the 
-  external OSC cue port.
+ports. One port is an internal *Sonic Pi* GUI port and the second is the 
+external OSC cue port.
 
 For >v4 a Token is needed to communicate with Sonic Pi. This token is generated
 randomly at runtime when Sonic-Pi is started. The Token is extracted from the sonic-pi log files. 
@@ -78,7 +83,7 @@ using the Token as the first argument in the message. The Token is automatically
 
 
 These values are found from the file `~/.sonic-pi/log/spider.log`
-.. code-block:: text
+::
     Sonic Pi Spider Server booting...
     The time is 2023-10-01 11:01:41 +0100
     Using primary protocol: udp

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ great music software created by Sam Aaron (http://sonic-pi.net).
 At the moment Python-Sonic works with Sonic Pi. It is planned, that it
 will work with Supercollider, too.
 
+This version supports Sonic Pi versions > 4 when OSC run-code security
+was added. 
+
 If you like it, use it. If you have some suggestions, tell me
 (gkvoelkl@nelson-games.de).
 
@@ -52,18 +55,50 @@ Changelog
 +--------+-------------------------------------------------------------+
 | 0.4.0  | Changes communication ports and recording                   |
 +--------+-------------------------------------------------------------+
+| 0.4.4  | Enables GUI Token                                           |
++--------+-------------------------------------------------------------+
 
 Communication
 -------------
 
-| The API *python-sonic* communications with *Sonic Pi* over UDP and two
-  ports. One port is an internal *Sonic Pi* port and could be changed.
-| For older *Sonic Pi* Version you have to set the ports explicitly
+The API *python-sonic* communications with *Sonic Pi* over UDP and two
+  ports. One port is an internal *Sonic Pi* GUI port and the second is the 
+  external OSC cue port.
+
+For >v4 a Token is needed to communicate with Sonic Pi. This token is generated
+randomly at runtime when Sonic-Pi is started. The Token is extracted from the sonic-pi log files. 
+Similarly, the GUI udp port is now randomised at start and must be read from the log file too. 
+In order to play notes (and not just send OSC cues), a connection must be made to the GUI udp port 
+using the Token as the first argument in the message. The Token is automatically used on send. 
 
 .. code-block:: python
 
     from psonic import *
-    set_server_parameter('127.0.0.1',4557,4559)
+    set_server_parameter('127.0.0.1', -2005799440, 30129, 4560)
+
+
+These values are found from the file `~/.sonic-pi/log/spider.log`
+.. code-block:: text
+    Sonic Pi Spider Server booting...
+    The time is 2023-10-01 11:01:41 +0100
+    Using primary protocol: udp
+    Detecting port numbers...
+    Ports: {:server_port=>30129, :gui_port=>30130, :scsynth_port=>30131, :scsynth_send_port=>30131, :osc_cues_port=>4560, :tau_port=>30132, :listen_to_tau_port=>30136}
+    Token: -2005799440
+    Opening UDP Server to listen to GUI on port: 30129
+    Spider - Pulling in modules...
+    Spider - Starting Runtime Server
+    ...
+
+This can be automated by using the function `set_server_parameter_from_log`
+
+.. code-block:: python
+
+    from psonic import *
+    set_server_parameter_from_log('127.0.0.1')
+    set_server_parameter_from_log('127.0.0.1', "path-to-log-file")
+
+Note if the `set_server_parameter` functions are not used, a default connection is created which will not work.
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,7 @@ That should work.
 
 For local development you might want to locally install using 
 
-::
-    $ pip install -e .
+$ pip install -e .
 
 Limitations
 -----------

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,12 @@ This can be automated by using the function `set_server_parameter_from_log`
 
 Note if the `set_server_parameter` functions are not used, a default connection is created which will not work.
 
+There is a simple example file `psonic_example.py` which you can run to check that things work. First open sonic-pi, then run the following:
+
+$ python psonic_example.py
+
+and a note should be played.
+
 Examples
 --------
 

--- a/psonic/synth_server.py
+++ b/psonic/synth_server.py
@@ -68,16 +68,14 @@ class SonicPi(SonicPiCommon):
         self._init_client()
 
     def _init_client(self):
-        self.client = udp_client.SimpleUDPClient(
+        self.client = udp_client.UDPClient(
             self.udp_ip,
             self.udp_port
         )
-        self.client.send_message("/run-code", [self.token, "play 70"])
-        self.client_for_messages = udp_client.SimpleUDPClient(
+        self.client_for_messages = udp_client.UDPClient(
             self.udp_ip,
             self.udp_port_osc_message
         )
-        print(f"Setup Clients: {self.udp_ip}:{self.udp_port}")
 
     def set_parameter(self, udp_ip = "", token = "", udp_port=-1, udp_port_osc_message=-1):
         super().set_parameter(udp_ip)

--- a/psonic/synth_server.py
+++ b/psonic/synth_server.py
@@ -37,16 +37,11 @@ class SonicPiCommon:
     def sample(self, command):
         self.send(command)
 
-## Ports could be find in home ./sonic-pi/log/server-output.log
-#     Version        3.2.0
-# Listen port:       51235  4557
-# Scsynth port:      51237  4556
-# Scsynth send port: 51237  4556
-# OSC cues port:      4560  4559
-# Erlang port:       51240  4560
-# OSC MIDI out port: 51238  4561
-# OSC MIDI in port:  51239  4562
-# Websocket port:    51241
+## Sonic Pi version 4.X: Ports can be found in 
+# Windows: C:/Users/<User>/.sonic-pi/log/spider.log
+# Linux: ~/.sonic-pi/log/spider.log
+# Both the server_port and Token are required
+# Default OSC Cues Port is still 4560
 
 ## Connection classes ##
 class SonicPi(SonicPiCommon):
@@ -57,7 +52,6 @@ class SonicPi(SonicPiCommon):
 
     #UDP_PORT_OSC_MESSAGE = 4559
     UDP_PORT_OSC_MESSAGE = 4560
-    GUI_ID = 'SONIC_PI_PYTHON'
 
     RUN_COMMAND = "/run-code"
     STOP_COMMAND = "/stop-all-jobs"
@@ -69,30 +63,34 @@ class SonicPi(SonicPiCommon):
         super().__init__()
         self.udp_port = self.UDP_PORT
         self.udp_port_osc_message = self.UDP_PORT_OSC_MESSAGE
+        self.token=None
 
         self._init_client()
 
     def _init_client(self):
-        self.client = udp_client.UDPClient(
+        self.client = udp_client.SimpleUDPClient(
             self.udp_ip,
             self.udp_port
         )
-        self.client_for_messages = udp_client.UDPClient(
+        self.client.send_message("/run-code", [self.token, "play 70"])
+        self.client_for_messages = udp_client.SimpleUDPClient(
             self.udp_ip,
             self.udp_port_osc_message
         )
+        print(f"Setup Clients: {self.udp_ip}:{self.udp_port}")
 
-    def set_parameter(self, udp_ip = "", udp_port=-1, udp_port_osc_message=-1):
+    def set_parameter(self, udp_ip = "", token = "", udp_port=-1, udp_port_osc_message=-1):
         super().set_parameter(udp_ip)
         if udp_port == -1: udp_port = self.UDP_PORT
         self.udp_port = udp_port
+        self.token=token
         if udp_port_osc_message == -1: udp_port_osc_message = self.UDP_PORT_OSC_MESSAGE
         self.udp_port_osc_message = udp_port_osc_message
 
         self._init_client()
 
     def play(self, command):
-        command = 'use_synth :{0}\n'.format(_current_synth.name) + command
+        command = f'use_synth :{_current_synth.name}\n{command}'
         self.send(command)
 
     def synth(self, command):
@@ -124,7 +122,9 @@ class SonicPi(SonicPiCommon):
 
     def send_command(self, address, argument=''):
         msg = osc_message_builder.OscMessageBuilder(address=address)
-        msg.add_arg('SONIC_PI_PYTHON')
+        if self.token is None:
+            raise RuntimeError("No token specified, please set token from file or manually before sending a command")
+        msg.add_arg(self.token)
         if argument != "":
             msg.add_arg(argument)
         msg = msg.build()

--- a/psonic_example.py
+++ b/psonic_example.py
@@ -1,0 +1,6 @@
+from psonic import *
+
+set_server_parameter_from_log("127.0.0.1")
+run("play 60")
+
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [
 
 setup(
     name='python-sonic',
-    version='0.4.3',
+    version='0.4.4',
     description='Programming Music with Sonic Pi or Supercollider',
     long_description=long_description,
     url='https://github.com/gkvoelkl/python-sonic',


### PR DESCRIPTION
The current version of python-sonic only support sonic-pi v3 as changes have been made to sonic-pi's treatment of non-cue OSC messages. This PR seeks to update python-sonic to support these new changes for v4+. This address #42 .

See this issue: https://github.com/sonic-pi-net/sonic-pi/issues/3330 for further details. 

In short, Sonic-Pi now randomises the GUI udp port and requires a Token to be sent with any non-cue OSC message like `/run-code`. Therefore this PR makes the following changes:

1. Updates `synth_server.py` with a new token field. `set_parameter` now also takes a token as the second argument. `send_command` now inserts the token before a command instead of the old `GUI_ID` parameter. 
2. Updates `psonic.py` with a new function `set_server_parameter_from_log` which by default parses the file `~/.sonic-pi/log/spider.log`, or allows the user to submit the `spider.log` file. The function parses the spider.log for the token, the server port and osc cues port and sets those as the server parameter. 
3. Adds a very simply example `psonic_example.py` for testing.
4. Updates the README.md to reflect the above changes. 

This has been tested on windows and linux. 

Let me know if you want any other updates. 